### PR TITLE
moved convert and color_convert python scripts to utilities

### DIFF
--- a/utilities/color_convert
+++ b/utilities/color_convert
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+import svgwrite
+import xml.etree.ElementTree as ET
+
+file = sys.argv[1] # first command line argument
+stroke_color = sys.argv[2] # second command line argument
+
+tree = ET.parse(file) # parses the svg xml
+root = tree.getroot()
+
+for element in root.iter(): # goes through all the elements in the xml and switches the stroke color
+    if "stroke" in element.attrib:
+        element.attrib["stroke"] = stroke_color
+
+tree.write(file) # writes new xml out to file

--- a/utilities/convert
+++ b/utilities/convert
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import pyembroidery
+import sys
+
+if len(sys.argv) < 3: 
+    sys.exit("Usage: {} <inputfilename> <outputfilename>".format(sys.argv[0]))
+
+pyembroidery.write(pyembroidery.read(sys.argv[1]), sys.argv[2])


### PR DESCRIPTION
I created a Python script called color_convert that allows people to change the color of the SVG to any hex value they may want, they simply need to specify an SVG file and the hex color that they want to convert the stroke of the pattern to. I then moved this script and the convert Python script used to convert between dst files to SVG files to a folder called utilities so that they can be used without cluttering the demo folder.